### PR TITLE
Add wedding seating arrangement app

### DIFF
--- a/seating-app/index.html
+++ b/seating-app/index.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Wedding Seating Arrangement</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Wedding Seating Arrangement</h1>
+
+    <div id="controls">
+        <label for="tableCount">Number of Tables: </label>
+        <input type="number" id="tableCount" min="1" value="1">
+        <button id="createTables">Create Tables</button>
+    </div>
+
+    <div id="guestInput">
+        <input type="text" id="guestName" placeholder="Guest name">
+        <button id="addGuest">Add Guest</button>
+    </div>
+
+    <div id="guestList"></div>
+
+    <div id="tables"></div>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/seating-app/script.js
+++ b/seating-app/script.js
@@ -1,0 +1,60 @@
+document.getElementById('createTables').addEventListener('click', () => {
+    const count = parseInt(document.getElementById('tableCount').value, 10);
+    const container = document.getElementById('tables');
+    container.innerHTML = '';
+    for (let i = 1; i <= count; i++) {
+        const table = document.createElement('div');
+        table.className = 'table';
+        table.dataset.tableId = i;
+        // create seats
+        for (let j = 0; j < 10; j++) {
+            const seat = document.createElement('div');
+            seat.className = 'seat';
+            seat.dataset.seatId = j;
+            seat.addEventListener('dragover', e => e.preventDefault());
+            seat.addEventListener('drop', handleDrop);
+            table.appendChild(seat);
+        }
+        positionSeats(table);
+        container.appendChild(table);
+    }
+});
+
+function positionSeats(table) {
+    const radius = 80;
+    const seats = table.querySelectorAll('.seat');
+    seats.forEach((seat, index) => {
+        const angle = (index / seats.length) * Math.PI * 2;
+        const x = Math.cos(angle) * radius + 90;
+        const y = Math.sin(angle) * radius + 90;
+        seat.style.left = `${x}px`;
+        seat.style.top = `${y}px`;
+    });
+}
+
+document.getElementById('addGuest').addEventListener('click', () => {
+    const nameInput = document.getElementById('guestName');
+    const name = nameInput.value.trim();
+    if (name) {
+        const guest = document.createElement('div');
+        guest.className = 'guest';
+        guest.textContent = name;
+        guest.draggable = true;
+        guest.addEventListener('dragstart', handleDragStart);
+        document.getElementById('guestList').appendChild(guest);
+        nameInput.value = '';
+    }
+});
+
+function handleDragStart(e) {
+    e.dataTransfer.setData('text/plain', e.target.textContent);
+    e.dataTransfer.effectAllowed = 'move';
+}
+
+function handleDrop(e) {
+    e.preventDefault();
+    const name = e.dataTransfer.getData('text/plain');
+    if (name) {
+        e.target.textContent = name;
+    }
+}

--- a/seating-app/style.css
+++ b/seating-app/style.css
@@ -1,0 +1,42 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+#guestList {
+    margin-top: 20px;
+    padding: 10px;
+    border: 1px solid #ccc;
+    min-height: 50px;
+}
+
+.guest {
+    padding: 5px 10px;
+    margin: 5px;
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
+    display: inline-block;
+    cursor: move;
+}
+
+.table {
+    position: relative;
+    width: 200px;
+    height: 200px;
+    border-radius: 50%;
+    border: 2px solid #333;
+    margin: 20px;
+    display: inline-block;
+}
+
+.seat {
+    position: absolute;
+    width: 60px;
+    height: 20px;
+    text-align: center;
+    line-height: 20px;
+    background-color: #eaeaea;
+    border: 1px solid #999;
+    border-radius: 4px;
+    cursor: pointer;
+}


### PR DESCRIPTION
## Summary
- add a `seating-app` folder with a simple drag-and-drop seating planner
- implement HTML controls to specify table count and enter guest names
- use CSS for round tables and seat styling
- add JavaScript to create tables, place seats in a circle and allow drag-and-drop of guest names

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868ba082984832bb687f872425c248b